### PR TITLE
去除可恶的 co 依赖

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -816,7 +816,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "zhongchiyu@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "co": "^4.6.0",
     "connect-redis": "^5.0.0",
     "debug": "^4.1.1",
     "express": "^4.17.1",

--- a/src/utility.js
+++ b/src/utility.js
@@ -22,7 +22,6 @@ exports.wrapRoute = (fn) => {
   }
   const newFn = function () {
     const next = arguments[arguments.length - 1]
-    console.log(fn.toString())
     return fn.apply(undefined, arguments)
       .catch(next)
   }


### PR DESCRIPTION
去除 co 依赖之后，以前的 middleware 需要重写，之前的 middleware 中没有 next 参数，去掉 co 模块之后需要 添加 next

## eg

### previous
```js
function (token) {
   return async function (req) {
      if (req.headers['authorization']) {
          //  xxxxx
     }
    return;
  }
}
```

### next

```js
function (token) {
   return async function (req, res, next) {
      if (req.headers['authorization']) {
         // xxx
     }
    return next()
  }
}
```